### PR TITLE
add Go 1.22 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,17 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         go:
+          - "1.22"
           - "1.21"
           - "1.20"
           - "1.19"
           - "1.18"
-        goexperiment: [""]
-        include:
-          # test with GOEXPERIMENT=loopvar
-          # https://github.com/golang/go/wiki/LoopvarExperiment
-          - os: ubuntu-latest
-            go: "1.21"
-            goexperiment: "loopvar"
 
     steps:
       - uses: actions/checkout@v4
@@ -34,8 +28,6 @@ jobs:
       - name: test
         run: |
           go test -v -coverprofile=profile.cov ./...
-        env:
-          GOEXPERIMENT: ${{ matrix.goexperiment }}
 
       - uses: shogo82148/actions-goveralls@v1
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the CI workflow by adjusting Go versions for testing. Removed specific experimental settings for Go 1.21 and added Go 1.22 to the testing matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->